### PR TITLE
Fix volumizer bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Most users will be interested in the web-app bassed interface for viewing the re
 
 ```
 bokeh-server &
-python interface_prototype.py
+python interface_prototype.py -hostname localhost -port 2121 -base_dir test_data
 ```
 
 The current implementation of this app is highly experimental and will change. Currently it just shows the results from the current run and will refresh the plots when a new run starts on the scanner.

--- a/interface_prototype.py
+++ b/interface_prototype.py
@@ -1,8 +1,13 @@
 import sys
+import logging
 import argparse
 from Queue import Queue, Empty
 from bokeh.plotting import figure, output_server, cursession, show, VBox
 import seaborn as sns
+
+
+logging.basicConfig()
+logger = logging.getLogger("rtfmri")
 
 
 from rtfmri import ScannerInterface, MotionAnalyzer, setup_exit_handler
@@ -15,8 +20,11 @@ if __name__ == "__main__":
     parser.add_argument("-username", default="")
     parser.add_argument("-password", default="")
     parser.add_argument("-base_dir", default="/export/home1/sdc_image_pool/images")
-    parser.add_argument("-debug_level", default=0)
+    parser.add_argument("-debug", action="store_true")
     args = parser.parse_args()
+
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
 
     output_server("rtfmri_prototype")
 
@@ -46,7 +54,7 @@ if __name__ == "__main__":
 
     scanner = ScannerInterface(hostname=args.hostname, port=args.port,
                                username=args.username, password=args.password,
-                               base_dir=args.base_dir, ftp_debug_level=args.debug_level)
+                               base_dir=args.base_dir)
     result_q = Queue()
     rtmotion = MotionAnalyzer(scanner, result_q)
 

--- a/rtfmri/queuemanagers.py
+++ b/rtfmri/queuemanagers.py
@@ -8,7 +8,7 @@ import logging
 import numpy as np
 import nibabel as nib
 
-logging.basicConfig(level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
 
 
@@ -279,7 +279,9 @@ class Volumizer(Finder):
                 # from this acquisition
                 instance_numbers_needed = np.arange(slices_per_volume) + 1
                 current_esa = this_esa
-                logger.debug("Collecting slices for new scanner run")
+                logger.debug(("Collecting slices for new scanner run - "
+                              "(exam: {} series: {} acquisition: {})"
+                              .format(*current_esa)))
 
             # Get the DICOM instance for this volume
             # This is an incremental index that reflects position in time
@@ -309,7 +311,9 @@ class Volumizer(Finder):
                     instance_numbers_gathered.pop(slice_index)
 
                 # Assemble all the slices together into a nibabel object
-                logger.debug("Assembling full volume")
+                logger.debug(("Assembling full volume for slices {:d}-{:d}"
+                              .format(min(instance_numbers_needed),
+                                      max(instance_numbers_needed))))
                 volume = self.assemble_volume(volume_slices)
 
                 # Put that object on the dicom queue

--- a/rtfmri/tests/test_queuemanagers.py
+++ b/rtfmri/tests/test_queuemanagers.py
@@ -51,7 +51,8 @@ class TestFinders(object):
         if self.no_server:
             raise SkipTest
 
-        series_dirs = self.client.series_dirs()
+        series_dirs = [s for s in self.client.series_dirs()
+                       if self.client.series_info(s)["NumTimepoints"] > 6]
 
         q = Queue()
         f = qm.SeriesFinder(self.client, q)
@@ -155,6 +156,14 @@ class TestFinders(object):
         dicom_q = Queue()
         series = "test_data/p004/e4120/4120_4_1_dicoms"
         files = self.client.series_files(series)[:80]
+
+        # Randomize the order of the files
+        # The dicoms in the test dataset happen to be in the
+        # correct temporal order when sorted by file name, but
+        # this is not garunteed and the code should be able to
+        # handle slices that are out of order
+        files = np.random.RandomState(0).permutation(files)
+
         for f in files:
             dicom_q.put(self.client.retrieve_dicom(f))
 


### PR DESCRIPTION
This changes the logic of the volumizer so that it explicity uses the
dicom instance numbers to order slices in each volume. This will make
robust to cases where the alphanumeric ordering of the dicom file names
does not correspond to the order of acquisition for each slice (#3).

Closes #3
