### PR TITLE
WIP: Allow SeriesFinder to skip early series

### DIFF
--- a/interface_prototype.py
+++ b/interface_prototype.py
@@ -20,6 +20,7 @@ if __name__ == "__main__":
     parser.add_argument("-username", default="")
     parser.add_argument("-password", default="")
     parser.add_argument("-base_dir", default="/export/home1/sdc_image_pool/images")
+    parser.add_argument("-skip", default=0, type=int)
     parser.add_argument("-debug", action="store_true")
     args = parser.parse_args()
 
@@ -55,6 +56,8 @@ if __name__ == "__main__":
     scanner = ScannerInterface(hostname=args.hostname, port=args.port,
                                username=args.username, password=args.password,
                                base_dir=args.base_dir)
+    scanner.series_finder.skip = args.skip
+
     result_q = Queue()
     rtmotion = MotionAnalyzer(scanner, result_q)
 

--- a/rtfmri/interface.py
+++ b/rtfmri/interface.py
@@ -24,6 +24,8 @@ class ScannerInterface(object):
         to the underlying scanner client objects.
 
         """
+        # TODO Should probably make it easier to pass parameters down to
+        # the different finders as they will likely get more functionality
         # Keep two different FTP clients for the series and
         # volume queues so they don't interfere with each other
         client1 = ScannerClient(*args, **kwargs)


### PR DESCRIPTION
This should make it easier to start the realtime motion tracker
midway through the scan.

Currently this doesn't seem to fully work. While it picks up the
specified scan correctly, it doesn't flip over to the next scan
when it finishes. The SeriesFinder does find a new series after
the subsequent one starts, but then a bunch of Dicoms get dumped
into the DicomFinder and they never get built into a full image.

Clearly, something is misaligned at some point.

The other issue is that the number of series that the SeriesFinder
sees does not seem to correspond to the number of series that the
scanner thinks it has run. This might be due to files like fieldmaps
that maybe do not end up on the FTP server in real time? This also
could be related to the issue above, I'm not sure.
